### PR TITLE
Update README w/Belt.Result usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ type person = {
 };
 
 module Decode = {
-  let personDecoder = json =>
+  let personDecoderExn = json =>
     Json.Decode.{
       age: json |> field("age", int),
       name: json |> field("name", string)
     };
+    
+  let personDecoder = json =>
+    try (Belt.Result.Ok(personDecoderExn(json))) {
+    | Json.Decode.DecodeError(err) => Belt.Result.Error(err)
+    };    
 };
 
 /* At app launch say you set your data state to `NotAsked` */


### PR DESCRIPTION
Recent changes made it so that `WebData.fromResponse()` does not except a raw `Json.Decode` function, but rather a `Belt.Result` to handle decoding with other types of decoder packages as well.

Updating the example found in `README.md` to reflect that change.

Refs https://github.com/FabienHenon/bs-remotedata/pull/2